### PR TITLE
path and namespacing don't match

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "license": "ISC",
     "autoload": {
         "psr-4": {
-            "Blubrry\\": "src/"
+            "Blubrry\\": "src/Blubrry/"
         }
     },
     "require-dev": {


### PR DESCRIPTION
the examples in README.md wouldn't work until composer.json "src" was updated to reflect the correct path and line up with the namespace in API.php